### PR TITLE
Flag to force or disable colored output

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ const (
 
 var (
 	Verbose      bool
+	NoColors     bool
 	rootPath     string
 	cfgFile      string
 	originConfig *viper.Viper
@@ -52,12 +53,14 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
+	rootCmd.PersistentFlags().BoolVar(&NoColors, "no-colors", false, "disable colored output")
+
 	initAurora()
 	cobra.OnInitialize(initConfig)
 	// re-init Aurora after config reading because `colors` can be specified in config
 	cobra.OnInitialize(initAurora)
 	log.SetOutput(os.Stdout)
-	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 }
 
 func initAurora() {
@@ -113,6 +116,9 @@ func check(e error) {
 // If `colors` explicitly specified in config, will return this value.
 // Otherwise enabled for TTY and disabled for non-terminal output.
 func EnableColors() bool {
+	if NoColors {
+		return false
+	}
 	if !viper.IsSet(colorsConfigKey) {
 		return isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd())
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -50,6 +50,7 @@ const (
 	skipConfigKey        string      = "skip"
 	skipEmptyConfigKey   string      = "skip_empty"
 	filesConfigKey       string      = "files"
+	colorsConfigKey      string      = "colors"
 	parallelConfigKey    string      = "parallel"
 	subFiles             string      = "{files}"
 	subAllFiles          string      = "{all_files}"


### PR DESCRIPTION
1. Disable colored output if `--no-colors` flag specified
1. Force colored output if `colors: true` specified in the config.
1. Disable colored output if `colors: false` specified in the config.
1. Use old behavior by default: enable colors only for TTY
1. `IsTTY` replaced by `EnableColors`, because now it's about colors, not TTY.

Close #33 

Should I update some docs or do some tests? I haven't noticed a good place for it in the current codebase.

Thank you for the nice tool!
