### PR TITLE
Fix typo in docs files

### DIFF
--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -436,4 +436,4 @@ lefthook uninstall
 ```
 
 ## More info
-Have a qustions? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).
+Have a question? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).

--- a/docs/other.md
+++ b/docs/other.md
@@ -47,4 +47,4 @@ lefthook install && lefthook run pre-commit
 ```
 
 ### More info
-Have a qustions? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).
+Have a question? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).

--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -33,4 +33,4 @@ lefthook install && lefthook run pre-commit
 If you see the error `lefthook: command not found` you need to check your $PATH. Also try to restart your terminal.
 
 ### More info
-Have a qustions? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).
+Have a question? Check the [wiki](https://github.com/Arkweid/lefthook/wiki).


### PR DESCRIPTION
The same as #37. I used "question" word, not "questions" to be consistent with #37.