### PR TITLE
Add --no-pager flag to brakeman

### DIFF
--- a/docs/other.md
+++ b/docs/other.md
@@ -34,7 +34,7 @@ pre-commit:
   parallel: true
   commands:
     audit:
-      run: brakeman
+      run: brakeman --no-pager
     rubocop:
       files: git diff --name-only @{push}
       glob: "*.{rb}"

--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -17,7 +17,7 @@ pre-commit:
   parallel: true
   commands:
     audit:
-      run: brakeman
+      run: brakeman --no-pager
     rubocop:
       files: git diff --name-only HEAD master
       glob: "*.{rb}"


### PR DESCRIPTION
I followed the configuration/setup for Ruby, and have the following lefthook.yml config:

```
---
pre-commit:
  commands:
    brakeman:
      run: bundle exec brakeman
```

I noticed that brakeman "gets stuck":

![image](https://user-images.githubusercontent.com/191564/62319119-485c0000-b46b-11e9-8568-e17e9606ed38.png)

I tried a number of flags (parallel, output, debug, bundler, no bundler, etc.) but I think the cause is the default paging behavior which the brakeman docs note [here](https://brakemanscanner.org/docs/options/):

> By default, Brakeman pages output to the terminal with the less pager. To have Brakeman output directly to terminal, use `brakeman --no-pager`

I thought this might be a useful improvement to the docs in case anyone else runs into this

I'm running macOS Mojave, brakeman 4.6.1 (via gem install), lefthook 0.6.3 (via gem install), ruby 2.6.3