### PR TITLE
Ruby example use staged for git diff

### DIFF
--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -19,7 +19,7 @@ pre-commit:
     audit:
       run: brakeman --no-pager
     rubocop:
-      files: git diff --name-only HEAD master
+      files: git diff --name-only --staged
       glob: "*.rb"
       run: rubocop {files}
 ```


### PR DESCRIPTION
`git diff --name-only HEAD master` doesn't show the _current_ files that
are staged for changes, only the previously committed changes

I think using `--staged` is a better example for the docs, because it will
run the command against the files you are committing. I think it better
represents what people expect to happen (the files I'm trying to commit will
have rubocop run against them)

I can throw an example git repo up w/ some examples of why I think this
is a better option to present as a default if that helps, but here's a screenshot:

![image](https://user-images.githubusercontent.com/191564/62635768-492ae100-b906-11e9-9074-54161c5ab921.png)

- I'm on a branch (off of master)
- I had 1 commit where I added `test.rb` file to the branch
- I have `foo_spec.rb` staged, and I'm adding it as a commit to the branch
 
Using `HEAD master` I only see the `test.rb` file in the output; so lefthook actually skips running rubocop on `foo_spec.rb` (which has a violation).

I expected lefthook to fail on the rubocop violation (file is staged, I'm committing it) but it did not, because it only looked at my previous committed file (`test.rb`)