### PR TITLE
Use relative path to script/executable file

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -254,6 +254,8 @@ func executeScript(hooksGroup, source string, executable os.FileInfo, wg *sync.W
 		makeExecutable(pathToExecutable)
 	}
 
+	pathToExecutable, _ = filepath.Rel(getRootPath(), pathToExecutable)
+
 	command := exec.Command(pathToExecutable, gitArgs[:]...)
 
 	if haveRunner(hooksGroup, scriptsConfigKey, executableName) {


### PR DESCRIPTION
It's PR fix https://github.com/Arkweid/lefthook/issues/81
Problem: `Lefthook` launches runner passing the absolute path to the executable.
The container having the volume mounted from the host machine which provides source code has other paths to the executable files in absolute form.

Solution - use a relative path to executable files.

Perhaps a better solution would be to use a key in a config file that will be determined in what form the path should be transmitted.