### PR TITLE
Add support for git-worktree

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"io/ioutil"
 	"log"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -138,7 +139,15 @@ func addLocalHookDir(hookName string, fs afero.Fs) {
 }
 
 func getGitHooksDir() string {
-	return filepath.Join(getRootPath(), gitHooksDir)
+	cmd := exec.Command("sh", "-c", "git rev-parse --git-common-dir")
+
+	outputBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+
+	gitDir := strings.TrimSpace(string(outputBytes))
+	return filepath.Join(gitDir, "hooks")
 }
 
 func isLefthookFile(pathFile string) bool {


### PR DESCRIPTION
lefthook can't recognize git-worktree directory.

```
mkdir repo
cd repo
git init

lefthook install
git add lefthook.yml && git commit -m "Initial commit"

git worktree add -b worktree-test-branch ../repo2
cd ../repo2
touch test.txt && git add test.txt && git commit -m "Update" test.txt # error!
```

This PR gives git-worktree support to lefthook.