### PR TITLE
Add possibility for using multiple file types (#101)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ const (
 	configLocalFileName     string      = "lefthook-local"
 	configExtendsOption     string      = "extends"
 	configExtension         string      = ".yml"
+	configExtensionPattern  string      = ".*"
 	defaultFilePermission   os.FileMode = 0755
 	defaultDirPermission    os.FileMode = 0666
 )
@@ -31,6 +32,7 @@ var (
 	rootPath     string
 	cfgFile      string
 	originConfig *viper.Viper
+	configFileExtensions = []string{".yml", ".yaml"}
 
 	au aurora.Aurora
 )

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -39,9 +39,17 @@ func deleteConfig(fs afero.Fs) {
 		log.Println(getConfigYamlPath(), "removed")
 	}
 
-	err = fs.Remove(getConfigLocalYamlPath())
-	if err == nil {
-		log.Println(getConfigLocalYamlPath(), "removed")
+	results, err := afero.Glob(fs, getConfigLocalYamlPattern())
+	if err != nil {
+		log.Println("Error occured while remove config file!:", err.Error())
+	}
+	for _, fileName := range results {
+		err = fs.Remove(getConfigLocalYamlPattern())
+		if err == nil {
+			log.Println(fileName, "removed")
+		} else {
+			log.Println("Error occured while remove config file!:", err.Error())
+		}
 	}
 }
 

--- a/spec/fixtures/lefthook.yaml
+++ b/spec/fixtures/lefthook.yaml
@@ -1,0 +1,9 @@
+pre-push:
+  scripts:
+    ok_script: ""
+    fail_script: ""
+
+pre-commit:
+  scripts:
+    ok_script: ""
+    fail_script: ""

--- a/spec/install_spec.rb
+++ b/spec/install_spec.rb
@@ -23,37 +23,15 @@ RSpec.describe 'install command' do
   end
 
   describe 'install after cloning repo with existed lefthook structure' do
-    let(:pre_push_hook) do
-      File.join(FileStructure.tmp, '.git', 'hooks', 'pre-push')
-    end
-    let(:pre_commit_hook) do
-      File.join(FileStructure.tmp, '.git', 'hooks', 'pre-commit')
-    end
-    let(:expected_pre_push_hook) { FileStructure.pre_push_hook_path }
-    let(:expected_pre_commit_hook) { FileStructure.pre_commit_hook_path }
-
     before do
       FileStructure.make_config
       FileStructure.make_scripts_preset
       _, @status = Open3.capture2(command)
     end
 
+    include_examples 'hook examples'
     it 'exit with 0 status' do
       expect(@status.success?).to be_truthy
-    end
-
-    it 'create pre-push git hook' do
-      expect(File.exist?(pre_push_hook)).to be_truthy
-      expect(
-        FileUtils.compare_file(expected_pre_push_hook, pre_push_hook)
-      ).to be_truthy
-    end
-
-    it 'create pre-commit git hook' do
-      expect(File.exist?(pre_commit_hook)).to be_truthy
-      expect(
-        FileUtils.compare_file(expected_pre_commit_hook, pre_commit_hook)
-      ).to be_truthy
     end
 
     it 'dont rename existed lefthook hook with .old extension' do

--- a/spec/support/file_structure.rb
+++ b/spec/support/file_structure.rb
@@ -29,16 +29,17 @@ class FileStructure
       FileUtils.remove_dir(tmp)
     end
 
-    def make_config
-      FileUtils.cp(config_yaml_path, tmp)
+    def make_config(extension = 'yml')
+      FileUtils.cp(config_yaml_path(extension), tmp)
     end
+
 
     def tmp
       @tmp ||= File.join(root, 'tmp')
     end
 
-    def config_yaml_path
-      File.join(fixtures, 'lefthook.yml')
+    def config_yaml_path(extension = 'yml')
+      File.join(fixtures, "lefthook.#{extension}")
     end
 
     def ok_script_path

--- a/spec/support/hook_examples.rb
+++ b/spec/support/hook_examples.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+RSpec.shared_examples "hook examples" do 
+  let(:pre_push_hook) do
+    File.join(FileStructure.tmp, '.git', 'hooks', 'pre-push')
+  end
+
+  let(:pre_commit_hook) do
+    File.join(FileStructure.tmp, '.git', 'hooks', 'pre-commit')
+  end
+
+  let(:expected_pre_push_hook) { FileStructure.pre_push_hook_path }
+  let(:expected_pre_commit_hook) { FileStructure.pre_commit_hook_path }
+
+  it 'create pre-push git hook' do
+    expect(File.exist?(pre_push_hook)).to be_truthy
+    expect(
+      FileUtils.compare_file(expected_pre_push_hook, pre_push_hook)
+    ).to be_truthy
+  end
+
+  it 'create pre-commit git hook' do
+    expect(File.exist?(pre_commit_hook)).to be_truthy
+    expect(
+      FileUtils.compare_file(expected_pre_commit_hook, pre_commit_hook)
+    ).to be_truthy
+  end
+end


### PR DESCRIPTION
Closes #101 
Added possibility to use files for a config with `yaml` extension.
Questions to discuss:
1. I haven't added tests, because locally they are failed even on the master, Do I need to perform something special?
2. In `cmd/install.go:189` you can see `primaryMatch`, this code will just take first match fr config file. Do we need anything special for it? (IMHO, no)