### PR TITLE
WIP: Add support for remote config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -165,13 +165,10 @@ func EnableColors() bool {
 
 func fetchRemoteExtends(uri string) io.Reader {
 	resp, err := http.Get(uri)
-	defer resp.Body.Close()
 	if err != nil {
 		log.Fatal("Error fetching remote config", uri, "\n", err)
 	}
-	if err != nil {
-		log.Fatal("Error reading remote config", uri, "\n", err)
-	}
+	defer resp.Body.Close()
 	return resp.Body
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"io"
+	"io/ioutil"
+	"bytes"
 	"path/filepath"
 	"strings"
 	"net/http"
@@ -169,7 +171,11 @@ func fetchRemoteExtends(uri string) io.Reader {
 		log.Fatal("Error fetching remote config", uri, "\n", err)
 	}
 	defer resp.Body.Close()
-	return resp.Body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal("Error reading remote config", uri, "\n", err)
+	}
+	return bytes.NewReader(body)
 }
 
 func isValidUrl(maybeUrl string) bool {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,7 @@ func initConfig() {
 		if isValidUrl(getExtendsPath()) {
 			uri := getExtendsPath()
 			baseRemoteConfig := fetchRemoteExtends(uri)
+			viper.SetConfigType("yaml")
 			err := viper.MergeConfig(baseRemoteConfig)
 			check(err)
 		} else {


### PR DESCRIPTION
👋 

I've been investigating adding lefthook to @artsy's repos, but thought it'd be nice to have some centralized config. I see you already support `extends`, but that relies on the files being already present. 

This PR will (hopefully) add the ability to specify `extends` as a URL. 

```yaml
extends: https://raw.githubusercontent.com/artsy/.github/master/base.yml
```

This is my first time ever using Go so please excuse any obvious blunders 🙏. I'll gladly update anything that doesn't match expectations/style of the project.

I still consider this a bit of a work-in-progress but I'd appreciate some early feedback. 

## Todo

- [ ] Add tests
- [ ] Add documentation