### PR TITLE
Update docker examples in guides

### DIFF
--- a/.npm/README.md
+++ b/.npm/README.md
@@ -127,7 +127,7 @@ If you are in the Docker environment. [Example](./docs/full_guide.md#referencing
 pre-commit:
   scripts:
     "good_job.js":
-      runner: docker exec -it --rm <container_id_or_name> {cmd}
+      runner: docker run -it --rm <container_id_or_name> {cmd}
 ```
 
 * ### **Local config**

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ If you are in the Docker environment. [Example](./docs/full_guide.md#referencing
 pre-commit:
   scripts:
     "good_job.js":
-      runner: docker exec -it --rm <container_id_or_name> {cmd}
+      runner: docker run -it --rm <container_id_or_name> {cmd}
 ```
 
 * ### **Local config**

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -286,7 +286,7 @@ You can wrap it in docker runner locally:
 pre-commit:
   scripts:
     "good_job.js":
-      runner: docker exec -it --rm <container_id_or_name> {cmd}
+      runner: docker run -it --rm <container_id_or_name> {cmd}
 ```
 
 `{cmd}` - shorthand for the command from `lefthook.yml`
@@ -383,7 +383,7 @@ pre-commit:
 
   scripts:
     "hello.js":
-      runner: docker exec -it --rm <container_id_or_name> {cmd}
+      runner: docker run -it --rm <container_id_or_name> {cmd}
   commands:
     govet:
       skip: true

--- a/examples/complete/lefthook-local.yml
+++ b/examples/complete/lefthook-local.yml
@@ -4,7 +4,7 @@ pre-commit:
     - backend
   scripts:
     "good_job.js":
-      runner: docker exec -it --rm <container_id_or_name> {cmd}
+      runner: docker run -it --rm <container_id_or_name> {cmd}
     "hello.go":
       runner: go run
 


### PR DESCRIPTION
Not a huge deal but `docker exec --rm` is not a valid command.
