### PR TITLE
Add yarn to template

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -81,6 +81,9 @@ then
 elif npx lefthook -h >/dev/null 2>&1
 then
   npx $cmd
+elif yarn lefthook -h >/dev/null 2>&1
+then
+  yarn $cmd
 else
   echo "Can't find lefthook in PATH"
 fi


### PR DESCRIPTION
If user doesn't have `npx` but has `yarn` we should check it and call `yarn $cmd`

`npx $cmd` and `yarn $cmd` do pretty much the same: execute binary from `node_modules`.

Tested this solution on my machine (I don't have `npx` and prefer `yarn`). Works as intended.