### PR TITLE
Feature: Ability to use multiple extends

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -100,7 +100,7 @@ func TestExtendsProperty(t *testing.T) {
 	viper.SetConfigType("yaml")
 
 	viper.ReadConfig(bytes.NewBuffer([]byte("")))
-	assert.True(t, isConfigExtends(), "Should not detect extends property")
+	assert.False(t, isConfigExtends(), "Should not detect extends property")
 
 	viper.ReadConfig(bytes.NewBuffer(yamlExampleString))
 	paths := getExtendsPath()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,13 +93,15 @@ func initConfig() {
 	viper.MergeInConfig()
 
 	if isConfigExtends() {
-		filename := filepath.Base(getExtendsPath())
-		extension := filepath.Ext(getExtendsPath())
-		name := filename[0 : len(filename)-len(extension)]
-		viper.SetConfigName(name)
-		viper.AddConfigPath(filepath.Dir(getExtendsPath()))
-		err := viper.MergeInConfig()
-		check(err)
+		for _, v := range getExtendsPath() {
+			filename := filepath.Base(v)
+			extension := filepath.Ext(v)
+			name := filename[0 : len(filename)-len(extension)]
+			viper.SetConfigName(name)
+			viper.AddConfigPath(filepath.Dir(v))
+			err := viper.MergeInConfig()
+			check(err)
+		}
 	}
 
 	viper.AutomaticEnv()
@@ -133,11 +135,19 @@ func check(e error) {
 }
 
 func isConfigExtends() bool {
-	return viper.GetString(configExtendsOption) != ""
+    if len(viper.GetStringSlice(configExtendsOption)) > 0 {
+      return true
+    }
+	return false
 }
 
-func getExtendsPath() string {
-	return viper.GetString(configExtendsOption)
+func getExtendsPath() []string {
+	extends := make([]string, 0, 10)
+	slices := viper.GetStringSlice(configExtendsOption)
+	for _, v := range slices {
+		extends = append(extends, v)
+	}
+	return extends
 }
 
 // EnableColors shows is colors supported for current output or not.

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -261,9 +261,11 @@ If you need to extend config from some another place, just add top level:
 ```yml
 # lefthook.yml
 
-extends: $HOME/work/lefthook-extend.yml
+extends: 
+  - $HOME/work/lefthook-extend.yml
+  - $HOME/work/lefthook-extend-2.yml
 ```
-NOTE: File for extend should have name NOT a "lefthook.yml"
+NOTE: Files for extend should have name NOT a "lefthook.yml" and should be unique.
 
 ## Referencing commands from lefthook.yml
 


### PR DESCRIPTION
Hello,
I would like to add the ability to use multiple extends. This was requested as a feature at my company as we are using Monorepo with many different projects (that are not separate git submodules), and using just one YML to manage all of those projects makes it become some GOD huge and unreadable file.

**With this PR in effect, you can define and use multiple extends like this:**
```
extends:
  - landing/lefthook-landing.yml
  - backend/lefthook-backend.yml
```

@Arkweid 🙏