### PR TITLE
feat(commands): added Git hook argument handling

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -156,9 +156,9 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 		for _, commandName := range commands {
 			wg.Add(1)
 			if getParallel(hooksGroup) {
-				go executeCommand(hooksGroup, commandName, &wg)
+				go executeCommand(hooksGroup, commandName, &wg, gitArgs)
 			} else {
-				executeCommand(hooksGroup, commandName, &wg)
+				executeCommand(hooksGroup, commandName, &wg, gitArgs)
 			}
 		}
 	}
@@ -174,7 +174,7 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 	return errors.New("Have failed script")
 }
 
-func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup) {
+func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup, gitArgs []string) {
 	defer wg.Done()
 
 	if getPiped(hooksGroup) && isPipeBroken {
@@ -221,6 +221,10 @@ func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup) {
 	runner = strings.Replace(runner, subStagedFiles, strings.Join(files, " "), -1)
 	runner = strings.Replace(runner, subAllFiles, strings.Join(files, " "), -1)
 	runner = strings.Replace(runner, subFiles, strings.Join(files, " "), -1)
+	runner = strings.Replace(runner, "{0}", strings.Join(gitArgs, " "), -1)
+	for gitArgIndex, gitArg := range gitArgs {
+		runner = strings.Replace(runner, fmt.Sprintf("{%d}", gitArgIndex+1), gitArg, -1)
+	}
 
 	command := exec.Command("sh", "-c", runner)
 	if cmdRoot != "" {

--- a/cmd/run_windows.go
+++ b/cmd/run_windows.go
@@ -151,9 +151,9 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 		for _, commandName := range commands {
 			wg.Add(1)
 			if getParallel(hooksGroup) {
-				go executeCommand(hooksGroup, commandName, &wg)
+				go executeCommand(hooksGroup, commandName, &wg, gitArgs)
 			} else {
-				executeCommand(hooksGroup, commandName, &wg)
+				executeCommand(hooksGroup, commandName, &wg, gitArgs)
 			}
 		}
 	}
@@ -169,7 +169,7 @@ func RunCmdExecutor(args []string, fs afero.Fs) error {
 	return errors.New("Have failed script")
 }
 
-func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup) {
+func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup, gitArgs []string) {
 	defer wg.Done()
 
 	if getPiped(hooksGroup) && isPipeBroken {
@@ -216,6 +216,10 @@ func executeCommand(hooksGroup, commandName string, wg *sync.WaitGroup) {
 	runner = strings.Replace(runner, subStagedFiles, strings.Join(files, " "), -1)
 	runner = strings.Replace(runner, subAllFiles, strings.Join(files, " "), -1)
 	runner = strings.Replace(runner, subFiles, strings.Join(files, " "), -1)
+	runner = strings.Replace(runner, "{0}", strings.Join(gitArgs, " "), -1)
+	for gitArgIndex, gitArg := range gitArgs {
+		runner = strings.Replace(runner, fmt.Sprintf("{%d}", gitArgIndex+1), gitArg, -1)
+	}
 
 	if isSkipCommmand(hooksGroup, commandName) {
 		mutex.Lock()

--- a/docs/full_guide.md
+++ b/docs/full_guide.md
@@ -137,6 +137,26 @@ pre-push:
 
 `{files}` - shorthand for a custom list of files
 
+## Git hook argument shorthands in commands
+
+If you want to use the original Git hook arguments in a command you can do it
+using the indexed shorthands:
+
+```yml
+# lefthook.yml
+
+# Note: commit-msg hook takes a single parameter,
+# the name of the file that holds the proposed commit log message.
+# Source: https://git-scm.com/docs/githooks#_commit_msg
+commit-msg:
+  commands:
+    multiple-sign-off:
+      run: 'test $(grep -c "^Signed-off-by: " {1}) -lt 2'
+```
+`{0}` - shorthand for the single space-joint string of Git hook arguments
+
+`{i}` - shorthand for the i-th Git hook argument
+
 ## Managing scripts
 
 If you run `lefthook add` command with `-d` flag, lefthook will create two directories where you can put scripts and reference them from `lefthook.yml` file.


### PR DESCRIPTION
**Type**: feature
**Scope**: commands
**Related issues**: fixes #133

### What is this?
Added functionality to propagate Git hook script invocation arguments to Lefthook commands in the form of positional shorthands such as `{1}` for the first argument, `{2}` for the second, etc.
Also introduced `{0}` as the equivalent shorthand of `{1} {2} ...` (space joint string of individual Git hook arguments) so all arguments can be passed down to command calls with one shorthand regardless of the actual argument count.

### Why?
To improve script vs. command feature parity and make commands able to use Git hook arguments directly.

Some Git hooks pass down arguments to the hook scripts to specify what is happening exactly.
An example is `commit-msg` where the file containing the proposed commit message is passed down as a positional argument - because it can be `.git/COMMIT_EDITMSG`, `.git/GITGUI_MSG` or another source.
In such cases this argument is best to be passed transparently to commands by Lefthook as well in order to be able to define simple commands using the exact proposed commit message or its file from the argument to do their work.