### PR TITLE
Improve performance with NPM package

### DIFF
--- a/.npm/bin/index.js
+++ b/.npm/bin/index.js
@@ -5,26 +5,13 @@ var path = require('path');
 
 var command_args = process.argv.slice(2);
 
-function spawnCommand(binaryExecutable) {
-    var child = spawn(
-        path.join(__dirname, binaryExecutable),
-        command_args,
-        { stdio: [process.stdin, process.stdout, process.stderr] });
+var child = spawn(
+    path.join(__dirname, 'lefthook'),
+    command_args,
+    { stdio: [process.stdin, process.stdout, process.stderr] });
 
-    child.on('close', function (code) {
-        if (code !== 0) {
-            process.exit(1);
-        }
-    });
-}
-
-if (process.platform === 'darwin') {
-    spawnCommand('lefthook-mac');
-} else if (process.platform === 'linux') {
-    spawnCommand('lefthook-linux');
-} else if (process.platform === 'win32') {
-    spawnCommand('lefthook-win.exe');
-} else {
-    console.log("Unsupported OS");
-    process.exit(1);
-}
+child.on('close', function (code) {
+    if (code !== 0) {
+        process.exit(1);
+    }
+});

--- a/.npm/bin/lefthook
+++ b/.npm/bin/lefthook
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    $dir/lefthook-linux $@
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    $dir/lefthook-mac $@
+elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
+    $dir/lefthook-win.exe $@
+else
+    Unsupported OS
+fi

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -69,12 +69,17 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
+dir="$(cd "$(dirname $(dirname $(dirname "${BASH_SOURCE[0]}")))" >/dev/null 2>&1 && pwd)"
+
 ` + autoInstall(hookName, fs) + "\n" + "cmd=\"lefthook run " + hookName + " $@\"" +
 		`
 
 if lefthook -h >/dev/null 2>&1
 then
   eval $cmd
+elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook"
+then
+  eval $dir/node_modules/@arkweid/lefthook/bin/$cmd
 elif bundle exec lefthook -h >/dev/null 2>&1
 then
   bundle exec $cmd
@@ -119,6 +124,9 @@ func autoInstall(hookName string, fs afero.Fs) string {
 if lefthook -h >/dev/null 2>&1
 then
 	eval $cmd
+elif test -f "$dir/node_modules/@arkweid/lefthook/bin/lefthook"
+then
+	eval $dir/node_modules/@arkweid/lefthook/bin/$cmd
 elif bundle exec lefthook -h >/dev/null 2>&1
 then
 	bundle exec $cmd


### PR DESCRIPTION
Using lefthook through the NPM package causes performance issues, because NPX is a bit slow to start and execute each time lefthook is invoked. This can especially being seen when doing rebases with dozens of commits.

Here's a basic benchmark between native binary and NPM:

```shell
# Native:
$ time lefthook version
0.7.2
lefthook version  0.01s user 0.01s system 85% cpu 0.014 total

# NPM:
$ time npx lefthook version
0.7.2
npx lefthook version  0.09s user 0.04s system 97% cpu 0.125 total
```

If you rebase some commits, it will take ~9 times longer to finish rebasing with NPM vs native binary.

This PR makes the hooks search for the final binaries by themselves, rather than using the `npx` command (which is now only used as a fallback).

Here's a benchmark comparing native binary, NPM before this PR, and NPM after this PR:

```shell
# Native:
$ time git rebase -i HEAD~3
Successfully rebased and updated refs/heads/my-branch-name.
git rebase -i HEAD~3  0.28s user 0.25s system 24% cpu 2.138 total

# NPM before this PR:
$ time git rebase -i HEAD~3
Successfully rebased and updated refs/heads/my-branch-name.
git rebase -i HEAD~3  2.50s user 0.95s system 70% cpu 4.887 total

# NPM after this PR:
$ time git rebase -i HEAD~3
Successfully rebased and updated refs/heads/my-branch-name.
git rebase -i HEAD~3  0.27s user 0.26s system 34% cpu 1.559 total
```

You can see this PR makes NPM as fast as the native binary.