### PR TITLE
Fix incompatible Bash features used in SH scripts

### DIFF
--- a/.npm/bin/lefthook
+++ b/.npm/bin/lefthook
@@ -1,13 +1,22 @@
 #!/bin/sh
 
-dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+dir="$(cd "$(dirname "$0")" >/dev/null 2>&1 || exit ; pwd -P)"
 
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    $dir/lefthook-linux $@
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    $dir/lefthook-mac $@
-elif [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "win32" ]]; then
-    $dir/lefthook-win.exe $@
-else
-    Unsupported OS
-fi
+UNAME=$(uname)
+case "$UNAME" in
+    Linux)
+        "$dir/lefthook-linux" "$@"
+        ;;
+    Darwin)
+        "$dir/lefthook-mac" "$@"
+        ;;
+    Windows*)
+        "$dir/lefthook-win.exe" "$@"
+        ;;
+    CYGWIN*)
+        "$dir/lefthook-win.exe" "$@"
+        ;;
+    *)
+        echo "Unsupported OS"
+        ;;
+esac

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -69,7 +69,7 @@ if [ -t 1 ] ; then
   exec < /dev/tty ; # <- enables interactive shell
 fi
 
-dir="$(cd "$(dirname $(dirname $(dirname "${BASH_SOURCE[0]}")))" >/dev/null 2>&1 && pwd)"
+dir="$(cd "$(dirname "$(dirname "$(dirname "$0")")")" >/dev/null 2>&1 || exit ; pwd -P)"
 
 ` + autoInstall(hookName, fs) + "\n" + "cmd=\"lefthook run " + hookName + " $@\"" +
 		`


### PR DESCRIPTION
This PR fixes bugs introduced in https://github.com/Arkweid/lefthook/pull/146#issuecomment-695076730. 

[The SH script used for NPM](https://github.com/Arkweid/lefthook/blob/58f641c74298adf7fb7fd7ae117875271aaa4c63/.npm/bin/lefthook) was written with poor knowledges of the differences between Bash and SH. I did some research and used https://www.shellcheck.net/ to help me rewrite properly the script and stay POSIX-compliant.

Please, tell me if you see any more issues.